### PR TITLE
Update Super-Linter version and job name

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -38,7 +38,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_CPP: false
-          VALIDATE_MARKDOWN: false
           FIX_YAML_PRETTIER: true
           FIX_MARKDOWN: true
           FIX_SHELL_SHFMT: true


### PR DESCRIPTION
Updated the linter configuration to use Super-Linter v7.1.0 and renamed the job.